### PR TITLE
Write release script for Linux

### DIFF
--- a/.github/workflows/manually-package.yaml
+++ b/.github/workflows/manually-package.yaml
@@ -4,6 +4,40 @@ on: workflow_dispatch
   
 
 jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: 'true'
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+          architecture: 'x64'
+
+      - name: Install dependencies
+        run: pip3 install -e .[dev]
+
+      - name: Infer the version from the main module
+        id: inferVersion
+        run: |
+          VERSION=$(python -c 'import skileu; print(skileu.__version__)')
+          echo "::set-output name=version::$VERSION"
+
+      - name: Package the release
+        run: |
+          pyinstaller skileu/main.py --name ski-leu --add-data "skileu:."
+          cd dist
+          zip -r ski-leu.${{ steps.inferVersion.outputs.version }}.linux-x64.zip ski-leu
+
+      - name: Upload the package
+        uses: actions/upload-artifact@v3
+        with:
+          name: ski-leu.${{ steps.inferVersion.outputs.version }}.linux-x64.zip
+          path: dist/ski-leu.${{ steps.inferVersion.outputs.version }}.linux-x64.zip
+
   build-windows:
     runs-on: windows-latest
 


### PR DESCRIPTION
We write a manual release script so that we can package for Linux on releases. We do not automate to allow for easier debugging at the moment.